### PR TITLE
Propose logic for modal visibility

### DIFF
--- a/app/components/modal.js
+++ b/app/components/modal.js
@@ -1,3 +1,9 @@
+
+/**
+ * Modal system
+ *
+ */
+
 'use strict';
 
 import React, {
@@ -16,8 +22,8 @@ export default class ModalComponent extends Component {
   }
   render(){
     return (
-      <Modal animated={true} visible={true} transparent={true}>
-        <View style={styles.container}>
+      <Modal animated={this.props.animated} visible={this.props.visible} transparent={true}>
+        <View style={this.props.visible ? styles.containerShow : styles.containerHide }>
           <Text style={styles.text}>Hello, modal!</Text>
         </View>
       </Modal>
@@ -27,14 +33,25 @@ export default class ModalComponent extends Component {
 
 ModalComponent.propTypes = {
   navigateTo: PropTypes.func.isRequired,
+  visible: PropTypes.bool.isRequired,
+  animated: PropTypes.bool,
+  transparent: PropTypes.bool,
+};
+
+ModalComponent.getDefaultProps = {
+  animated: false,
+  transparent: true,
 };
 
 const styles = StyleSheet.create({
-  container: {
+  containerShow: {
     flex: 1,
-    backgroundColor: 'transparent',
+    backgroundColor: 'rgba(0, 0, 0, 0.5)',
     justifyContent: 'center',
     alignItems: 'center',
+  },
+  containerHide: {
+    flex: 0,
   },
   text: {
     fontSize: 20,


### PR DESCRIPTION
@izaakrogan can you have a look at this, it's directed to your `fix-view` branch.

Is there a way to not show the modal only through style?
Or are we forced to do something like this:

``` js
if (this.props.visible === true){
  <Modal> // modal
} else {
  <View> // empty view
}
```

Happy to implement any suggestion
